### PR TITLE
Escapes A+ string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-ikr",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "The stuff you like, Hubot likes them too",
   "main": "index.coffee",
   "author": {

--- a/src/ikr.coffee
+++ b/src/ikr.coffee
@@ -48,7 +48,7 @@ triggers = [
   "I love",
   "(fantastic|wonderful|outstanding|magnificent|brilliant|genius|amazing)",
   "(ZOMG|OMG|OMFG)",
-  "A+",
+  "A\+",
   "(so|pretty) great",
   "off the hook"
 ]


### PR DESCRIPTION
I found hubot to trigger on all words beginning with A. Figured this would be a good fix.
